### PR TITLE
Add user_id to snap-in-context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devrev/typescript-sdk",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@devrev/typescript-sdk",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "license": "MIT",
       "dependencies": {
         "@types/yargs": "^17.0.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devrev/typescript-sdk",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "description": "## SDK Generation",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/snap-ins/types.test.ts
+++ b/src/snap-ins/types.test.ts
@@ -11,6 +11,8 @@ const SNAP_IN_VERSION_ID =
   'don:integration:dvrv-us-1:devo/TEST-DEVORG:snap_in_package/00000000-0000-0000-0000-000000000000';
 const SERVICE_ACCOUNT_ID =
   'don:identity:dvrv-us-1:devo/TEST-DEVORG:svcacc/00000000-0000-0000-0000-000000000000';
+const USER_ID =
+  'don:identity:dvrv-us-1:devo/TEST-DEVORG:devu/123';
 
 describe('Snap-ins types', () => {
   describe('Context', () => {
@@ -22,6 +24,7 @@ describe('Snap-ins types', () => {
         snap_in_version_id: SNAP_IN_VERSION_ID,
         service_account_id: SERVICE_ACCOUNT_ID,
         secrets: { secret1: 'value1', secret2: 'value2' },
+        user_id: USER_ID,
       };
 
       expect(context).toHaveProperty('dev_oid');
@@ -30,6 +33,7 @@ describe('Snap-ins types', () => {
       expect(context).toHaveProperty('snap_in_version_id');
       expect(context).toHaveProperty('service_account_id');
       expect(context).toHaveProperty('secrets');
+      expect(context).toHaveProperty('user_id');
     });
   });
 
@@ -72,6 +76,7 @@ describe('Snap-ins types', () => {
           snap_in_version_id: SNAP_IN_VERSION_ID,
           service_account_id: SERVICE_ACCOUNT_ID,
           secrets: { secret1: 'value1', secret2: 'value2' },
+          user_id: USER_ID,
         },
         execution_metadata: {
           request_id: 'request-123',

--- a/src/snap-ins/types.ts
+++ b/src/snap-ins/types.ts
@@ -31,6 +31,10 @@ export type Context = {
    * `actor_session_token`: For commands, and snap-kits, where the user is performing some action, this is the token of the user who is performing the action.
    */
   secrets: Record<string, string>;
+  /**
+   * The ID of the user on whose behalf the function is being invoked.
+   */
+  user_id?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary
This field is needed by the snap-in developers to identify on whose behalf the automation is running. i.e. It is mainly used for user-level event sources.

ISS-103471

